### PR TITLE
Windows support

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,7 +92,11 @@ async def register(message: types.Message):
         await message.answer('Не пытайся меня обмануть')
         return
 
-    user_data = settings.DB.get(message.contact.phone_number)
+    phone_number = message.contact.phone_number
+    if not phone_number.startswith('+'):
+        phone_number = f'+{phone_number}'
+
+    user_data = settings.DB.get(phone_number)
     if not user_data:
         data = await state.get_data()
         data['fraud'] = data.setdefault('fraud', 0) + 1

--- a/wake_on_lan.py
+++ b/wake_on_lan.py
@@ -1,6 +1,7 @@
 import asyncio
 import pathlib
 import socket
+import sys
 import warnings
 
 import settings
@@ -187,11 +188,15 @@ async def connect(addr):
     else:
         family = 0
 
+    kwargs = {}
+    if sys.platform == 'linux':
+        kwargs['allow_broadcast'] = True
+
     transport, protocol = await loop.create_datagram_endpoint(
         lambda: Protocol(recvq, excq, drained),
         remote_addr=addr,
         family=family,
-        allow_broadcast=True,
+        **kwargs,
     )
 
     return DatagramClient(transport, recvq, excq, drained)


### PR DESCRIPTION
There was a problem on Windows. It turned out that the  `allow_broadcast` parameter is necessary only for linux.
The problem with phone numbers was fixed as well.